### PR TITLE
Id as uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "fs-extra": "^10.1.0",
         "http-errors": "2.0.0",
         "mongoose": "^6.3.3",
-        "uuidv4": "^6.2.13",
+        "uuid": "^8.3.2",
         "winston": "^3.7.2"
       },
       "devDependencies": {
@@ -1585,11 +1585,6 @@
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
       "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
       "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/webidl-conversions": {
       "version": "6.1.1",
@@ -7920,15 +7915,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/uuidv4": {
-      "version": "6.2.13",
-      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
-      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
-      "dependencies": {
-        "@types/uuid": "8.3.4",
-        "uuid": "8.3.2"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -9411,11 +9397,6 @@
       "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.3.tgz",
       "integrity": "sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==",
       "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "@types/webidl-conversions": {
       "version": "6.1.1",
@@ -14183,15 +14164,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-    },
-    "uuidv4": {
-      "version": "6.2.13",
-      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
-      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
-      "requires": {
-        "@types/uuid": "8.3.4",
-        "uuid": "8.3.2"
-      }
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "fs-extra": "^10.1.0",
     "http-errors": "2.0.0",
     "mongoose": "^6.3.3",
-    "uuidv4": "^6.2.13",
+    "uuid": "^8.3.2",
     "winston": "^3.7.2"
   },
   "devDependencies": {

--- a/src/controller/commonController.js
+++ b/src/controller/commonController.js
@@ -1,6 +1,6 @@
 const { NotFound } = require('http-errors')
 const Page = require('../util/page.js')
-const { uuid: uuidv4 } = require('uuidv4')
+const { v4: uuidv4 } = require('uuid')
 const { buildQuery } = require('../util/fiqlQueryBuilder.js')
 /**
  * List Entity

--- a/src/controller/commonController.js
+++ b/src/controller/commonController.js
@@ -46,7 +46,7 @@ async function list (model, request, reply) {
  * @param {import('fastify').FastifyReply} reply
  */
 async function byId (model, request, reply) {
-  const query = { id: request.params.id }
+  const query = { _id: request.params.id }
   const result = await model.findOne(query)
 
   if (!result) {
@@ -62,12 +62,12 @@ async function byId (model, request, reply) {
  * @param {import('fastify').FastifyReply} reply
  */
 async function create (model, request, reply) {
-  const id = uuidv4()
-  const data = { ...request.body, id, includedAt: new Date(), updatedAt: new Date() }
+  const _id = request.body._id ?? uuidv4()
+  const data = { ...request.body, _id, includedAt: new Date(), updatedAt: new Date() }
   await model.insertMany([
     data
   ])
-  reply.code(201).header('Location', `${request.routerPath}/${id}`).send()
+  reply.code(201).header('Location', `${request.routerPath}/${_id}`).send()
 }
 
 /**
@@ -78,10 +78,10 @@ async function create (model, request, reply) {
 async function update (model, request, reply) {
   const entity = request.body
   delete entity.updatedAt
-  delete entity.id
+  delete entity._id
 
   const query = { _id: request.params.id }
-  const data = { ...entity, id: request.params.id, updatedAt: new Date() }
+  const data = { ...entity, _id: request.params.id, updatedAt: new Date() }
   const result = await model.updateOne(query, data)
 
   if (result.modifiedCount <= 0) {
@@ -100,7 +100,7 @@ async function update (model, request, reply) {
 async function partialUpdate (model, request, reply) {
   const entity = request.body
   delete entity.updatedAt
-  delete entity.id
+  delete entity._id
 
   const query = { _id: request.params.id }
   const data = { ...entity, _id: request.params.id, updatedAt: new Date() }

--- a/src/controller/commonController.js
+++ b/src/controller/commonController.js
@@ -9,16 +9,15 @@ const { buildQuery } = require('../util/fiqlQueryBuilder.js')
  * @param {import('fastify').FastifyReply} reply
  */
 async function list (model, request, reply) {
-  const query = buildQuery(model, request.query)
+  const q = buildQuery(model, request.query)
 
   let entities
   let count
-  const entitiesPromise = query.exec().then((e) => {
+  const entitiesPromise = q.pageQuery.exec().then((e) => {
     entities = e
   })
   // @TODO Count only entities on filter
-  const countPromise = model
-    .count({})
+  const countPromise = q.countQuery
     .exec()
     .then((c) => {
       count = c
@@ -31,7 +30,7 @@ async function list (model, request, reply) {
     entities,
     request.query.offset,
     request.query.limit,
-    count
+    count[0]?.count ?? count
   )
 
   return reply

--- a/src/controller/diagram.js
+++ b/src/controller/diagram.js
@@ -81,10 +81,10 @@ async function convertEdgeToReactFlow (edges) {
   for (const item of edges) {
     newlist.push({
       id: item._id,
-      sourceHandle: item.sourceHandle,
-      targetHandle: item.targetHandle,
-      source: item.relation.source,
-      target: item.relation.target,
+      sourceHandle: item.source.handle,
+      targetHandle: item.target.handle,
+      source: item.source.node,
+      target: item.target.node,
       data: {
         description: item.relation.description,
         detail: item.relation.detail
@@ -102,14 +102,14 @@ async function convertNodeToReactFlow (nodes) {
   const newlist = []
   for (const item of nodes) {
     newlist.push({
-      id: item.entity._id,
+      id: item._id,
       position: {
         x: item.x,
         y: item.y
       },
       data: { name: item.entity.name, description: item.entity.description ?? '' },
       type: item.entity.type,
-      nodeId: item._id
+      entity: item.entity._id
     })
   }
   return newlist

--- a/src/controller/node.js
+++ b/src/controller/node.js
@@ -1,7 +1,7 @@
-const { NotFound } = require('http-errors')
 const { nodeModel } = require('../model/node')
 const { entityModel } = require('../model/entity')
 const commonController = require('./commonController.js')
+const { v4: uuidv4 } = require('uuid')
 
 /**
  * List nodes
@@ -41,8 +41,9 @@ async function create (request, reply) {
   }
   const entityDbResult = await entityModel().create(entity)
 
-  // TODO check if thos relation exists
+  // TODO check if this relation exists
   const node = {
+    _id: request.body._id ?? uuidv4(),
     x: request.body.x,
     y: request.body.y,
     entity: entityDbResult._id,
@@ -69,26 +70,7 @@ async function update (request, reply) {
  * @param {import('fastify').FastifyReply} reply
  */
 async function partialUpdate (request, reply) {
-  // the id node that came here is from the entity object that do not match with the local id
-  // so update the node considering the diagramId and entityId
-  // and update the data
-  const entity = request.body
-  const query = {
-    entity: request.params.id,
-    diagram: request.body.diagram
-  }
-  const toUpdate = { ...entity, id: request.params.id, updatedAt: new Date() }
-
-  const result = await nodeModel().updateOne(
-    query,
-    toUpdate
-  )
-
-  if (result.modifiedCount <= 0) {
-    throw new NotFound('Entity not found')
-  }
-
-  reply.status(201).send()
+  return commonController.partialUpdate(nodeModel(), request, reply)
 }
 
 /**

--- a/src/model/diagram.js
+++ b/src/model/diagram.js
@@ -1,13 +1,14 @@
 const mongoose = require('mongoose')
 const { entityModel } = require('./entity.js')
+const { v4: uuidv4 } = require('uuid')
 
 const { Schema } = mongoose
 
 const diagramSchema = new Schema({
-  id: String,
+  _id: { type: String, default: uuidv4 },
   name: String,
   entity: {
-    type: Schema.Types.String,
+    type: String,
     ref: entityModel(),
     relationship: {
       type: 'ONE_TO_ONE',

--- a/src/model/diagram.js
+++ b/src/model/diagram.js
@@ -13,7 +13,7 @@ const diagramSchema = new Schema({
     relationship: {
       type: 'ONE_TO_ONE',
       localField: 'source',
-      foreignField: 'id'
+      foreignField: '_id'
     }
   },
   includedAt: Date,

--- a/src/model/diagramItem.js
+++ b/src/model/diagramItem.js
@@ -1,13 +1,14 @@
 const mongoose = require('mongoose')
 const { diagramModel } = require('./diagram')
+const { v4: uuidv4 } = require('uuid')
 
 const { Schema } = mongoose
 const options = { discriminatorKey: 'kind' }
 
 const diagramItemSchema = new Schema({
-  id: String,
+  _id: { type: String, default: uuidv4 },
   diagram: {
-    type: Schema.Types.String,
+    type: String,
     ref: diagramModel(),
     relationship: {
       type: 'ONE_TO_ONE',

--- a/src/model/diagramItem.js
+++ b/src/model/diagramItem.js
@@ -13,7 +13,7 @@ const diagramItemSchema = new Schema({
     relationship: {
       type: 'ONE_TO_ONE',
       localField: 'diagram',
-      foreignField: 'id'
+      foreignField: '_id'
     }
   },
   includedAt: Date,

--- a/src/model/edge.js
+++ b/src/model/edge.js
@@ -1,19 +1,42 @@
 const mongoose = require('mongoose')
 const { diagramItemModel } = require('./diagramItem')
 const { relationModel } = require('./relation')
+const { nodeModel } = require('./node')
 
 const { Schema } = mongoose
 const options = { discriminatorKey: 'kind' }
 
 const edgeSchema = new Schema({
-  sourceHandle: String,
-  targetHandle: String,
+  source: new Schema({
+    handle: String,
+    node: {
+      type: String,
+      ref: nodeModel(),
+      relationship: {
+        type: 'ONE_TO_ONE',
+        localField: 'node',
+        foreignField: '_id'
+      }
+    }
+  }),
+  target: new Schema({
+    handle: String,
+    node: {
+      type: String,
+      ref: nodeModel(),
+      relationship: {
+        type: 'ONE_TO_ONE',
+        localField: 'node',
+        foreignField: '_id'
+      }
+    }
+  }),
   relation: {
     type: String,
     ref: relationModel(),
     relationship: {
       type: 'ONE_TO_ONE',
-      localField: 'source',
+      localField: 'relation',
       foreignField: '_id'
     }
   }

--- a/src/model/edge.js
+++ b/src/model/edge.js
@@ -9,7 +9,7 @@ const edgeSchema = new Schema({
   sourceHandle: String,
   targetHandle: String,
   relation: {
-    type: Schema.Types.String,
+    type: String,
     ref: relationModel(),
     relationship: {
       type: 'ONE_TO_ONE',

--- a/src/model/edge.js
+++ b/src/model/edge.js
@@ -14,7 +14,7 @@ const edgeSchema = new Schema({
     relationship: {
       type: 'ONE_TO_ONE',
       localField: 'source',
-      foreignField: 'id'
+      foreignField: '_id'
     }
   }
 })

--- a/src/model/entity.js
+++ b/src/model/entity.js
@@ -1,9 +1,10 @@
 const mongoose = require('mongoose')
+const { v4: uuidv4 } = require('uuid')
 
 const { Schema } = mongoose
 
 const entitySchema = new Schema({
-  id: String,
+  _id: { type: String, default: uuidv4 },
   name: String,
   description: String,
   type: {

--- a/src/model/node.js
+++ b/src/model/node.js
@@ -9,7 +9,7 @@ const nodeSchema = new Schema({
   x: Number,
   y: Number,
   entity: {
-    type: Schema.Types.String,
+    type: String,
     ref: entityModel(),
     relationship: {
       type: 'ONE_TO_ONE',

--- a/src/model/node.js
+++ b/src/model/node.js
@@ -14,7 +14,7 @@ const nodeSchema = new Schema({
     relationship: {
       type: 'ONE_TO_ONE',
       localField: 'source',
-      foreignField: 'id'
+      foreignField: '_id'
     }
   }
 })

--- a/src/model/relation.js
+++ b/src/model/relation.js
@@ -14,7 +14,7 @@ const relationSchema = new Schema({
     relationship: {
       type: 'ONE_TO_ONE',
       localField: 'source',
-      foreignField: 'id'
+      foreignField: '_id'
     }
   },
   target: {
@@ -23,7 +23,7 @@ const relationSchema = new Schema({
     relationship: {
       type: 'ONE_TO_ONE',
       localField: 'source',
-      foreignField: 'id'
+      foreignField: '_id'
     }
   },
   includedAt: Date,

--- a/src/model/relation.js
+++ b/src/model/relation.js
@@ -1,14 +1,15 @@
 const mongoose = require('mongoose')
 const { entityModel } = require('./entity')
+const { v4: uuidv4 } = require('uuid')
 
 const { Schema } = mongoose
 
 const relationSchema = new Schema({
-  id: String,
+  _id: { type: String, default: uuidv4 },
   description: String,
   detail: String,
   source: {
-    type: Schema.Types.String,
+    type: String,
     ref: entityModel(),
     relationship: {
       type: 'ONE_TO_ONE',
@@ -17,7 +18,7 @@ const relationSchema = new Schema({
     }
   },
   target: {
-    type: Schema.Types.String,
+    type: String,
     ref: entityModel(),
     relationship: {
       type: 'ONE_TO_ONE',

--- a/src/model/relation.js
+++ b/src/model/relation.js
@@ -22,7 +22,7 @@ const relationSchema = new Schema({
     ref: entityModel(),
     relationship: {
       type: 'ONE_TO_ONE',
-      localField: 'source',
+      localField: 'target',
       foreignField: '_id'
     }
   },

--- a/src/repository/seed.js
+++ b/src/repository/seed.js
@@ -29,46 +29,136 @@ const clear = async () => {
 }
 
 const createView1 = async (diagram, systems, relations) => {
-  await nodeModel().insertMany([
-    { x: 0, y: 0, entity: systems[0]._id, diagram: diagram._id, includedAt: new Date() },
-    { x: 500, y: 0, entity: systems[1]._id, diagram: diagram._id, includedAt: new Date() }
+  const nodes = await nodeModel().insertMany([
+    {
+      x: 0,
+      y: 0,
+      entity: systems[0]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    },
+    {
+      x: 500,
+      y: 0,
+      entity: systems[1]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    }
   ])
 
   await edgeModel().insertMany([
-    { sourceHandle: 'r', targetHandle: 'l', relation: relations[0]._id, diagram: diagram._id, includedAt: new Date() }
+    {
+      source: { handle: 'r', node: nodes[0]._id },
+      target: { handle: 'l', node: nodes[1]._id },
+      relation: relations[0]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    }
   ])
 }
 const createView2 = async (diagram, systems, relations) => {
-  await nodeModel().insertMany([
-    { x: -30, y: 10, entity: systems[0]._id, diagram: diagram._id, includedAt: new Date() },
-    { x: 91, y: 54, entity: systems[2]._id, diagram: diagram._id, includedAt: new Date() }
+  const nodes = await nodeModel().insertMany([
+    {
+      x: 0,
+      y: 0,
+      entity: systems[0]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    },
+    {
+      x: 500,
+      y: 0,
+      entity: systems[2]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    }
   ])
 
   await edgeModel().insertMany([
-    { sourceHandle: 'r', targetHandle: 'l', relation: relations[1]._id, diagram: diagram._id, includedAt: new Date() }
+    {
+      source: { handle: 'r', node: nodes[0] },
+      target: { handle: 'l', node: nodes[1] },
+      relation: relations[1]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    }
   ])
 }
 const createView3 = async (diagram, systems, relations) => {
-  await nodeModel().insertMany([
-    { x: -30, y: 10, entity: systems[0]._id, diagram: diagram._id, includedAt: new Date() },
-    { x: 91, y: 54, entity: systems[2]._id, diagram: diagram._id, includedAt: new Date() }
+  const nodes = await nodeModel().insertMany([
+    {
+      x: 0,
+      y: 0,
+      entity: systems[0]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    },
+    {
+      x: 500,
+      y: 0,
+      entity: systems[2]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    }
   ])
 
   await edgeModel().insertMany([
-    { sourceHandle: 'r', targetHandle: 'l', relation: relations[2]._id, diagram: diagram._id, includedAt: new Date() }
+    {
+      source: { handle: 'r', node: nodes[0] },
+      target: { handle: 'l', node: nodes[1] },
+      relation: relations[2]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    }
   ])
 }
 const createView4 = async (diagram, systems, relations) => {
-  await nodeModel().insertMany([
-    { x: -30, y: 10, entity: systems[0]._id, diagram: diagram._id, includedAt: new Date() },
-    { x: 99, y: -59, entity: systems[1]._id, diagram: diagram._id, includedAt: new Date() },
-    { x: 91, y: 54, entity: systems[2]._id, diagram: diagram._id, includedAt: new Date() }
+  const nodes = await nodeModel().insertMany([
+    {
+      x: 0,
+      y: 0,
+      entity: systems[0]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    },
+    {
+      x: 500,
+      y: 0,
+      entity: systems[1]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    },
+    {
+      x: 500,
+      y: 300,
+      entity: systems[2]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    }
   ])
 
   await edgeModel().insertMany([
-    { sourceHandle: 'r', targetHandle: 'l', relation: relations[0]._id, diagram: diagram._id, includedAt: new Date() },
-    { sourceHandle: 'r', targetHandle: 'l', relation: relations[1]._id, diagram: diagram._id, includedAt: new Date() },
-    { sourceHandle: 'r', targetHandle: 'l', relation: relations[2]._id, diagram: diagram._id, includedAt: new Date() }
+    {
+      source: { handle: 'r', node: nodes[0] },
+      target: { handle: 'l', node: nodes[1] },
+      relation: relations[0]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    },
+    {
+      source: { handle: 'r', node: nodes[0] },
+      target: { handle: 'l', node: nodes[2] },
+      relation: relations[1]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    },
+    {
+      source: { handle: 'r', node: nodes[0] },
+      target: { handle: 'l', node: nodes[2] },
+      relation: relations[2]._id,
+      diagram: diagram._id,
+      includedAt: new Date()
+    }
   ])
 }
 const loadDiagram = async () => {
@@ -138,4 +228,6 @@ const loadSystem = async () => {
   return res
 }
 
-seedDb().then(async () => { await disconnectMongo() })
+seedDb().then(async () => {
+  await disconnectMongo()
+})

--- a/src/schema/diagram.js
+++ b/src/schema/diagram.js
@@ -4,7 +4,7 @@ const diagramSchema =
   type: 'object',
   required: ['name'],
   properties: {
-    id: {
+    _id: {
       type: 'string',
       format: 'uuid'
     },

--- a/src/schema/diagramItem.js
+++ b/src/schema/diagramItem.js
@@ -3,7 +3,7 @@ const diagramItemSchema = {
   type: 'object',
   required: ['diagram'],
   properties: {
-    id: {
+    _id: {
       type: 'string'
     },
     diagram: {

--- a/src/schema/edge.js
+++ b/src/schema/edge.js
@@ -10,11 +10,29 @@ const edgeSchema = {
       type: 'object',
       required: ['name'],
       properties: {
-        sourceHandle: {
-          type: 'string'
+        source: {
+          type: 'object',
+          required: ['handle', 'node'],
+          properties: {
+            handle: {
+              type: 'string'
+            },
+            node: {
+              $ref: 'node'
+            }
+          }
         },
-        targetHandle: {
-          type: 'string'
+        target: {
+          type: 'object',
+          required: ['handle', 'node'],
+          properties: {
+            handle: {
+              type: 'string'
+            },
+            node: {
+              $ref: 'node'
+            }
+          }
         },
         relation: {
           $ref: 'relation'
@@ -26,13 +44,32 @@ const edgeSchema = {
 
 const edgeUpsertSchema = JSON.parse(JSON.stringify(diagramItemUpsertSchema))
 edgeUpsertSchema.properties = { ...diagramItemUpsertSchema.properties }
-edgeUpsertSchema.properties.sourceHandle = {
-  type: 'string'
+edgeUpsertSchema.properties.source = {
+  type: 'object',
+  required: ['handle', 'node'],
+  properties: {
+    handle: {
+      type: 'string'
+    },
+    node: {
+      format: 'uuid',
+      type: 'string'
+    }
+  }
 }
-edgeUpsertSchema.properties.targetHandle = {
-  type: 'string'
+edgeUpsertSchema.properties.target = {
+  type: 'object',
+  required: ['handle', 'node'],
+  properties: {
+    handle: {
+      type: 'string'
+    },
+    node: {
+      format: 'uuid',
+      type: 'string'
+    }
+  }
 }
-
 edgeUpsertSchema.properties.relation = {
   format: 'uuid',
   type: 'string'

--- a/src/schema/entity.js
+++ b/src/schema/entity.js
@@ -3,7 +3,7 @@ const entitySchema = {
   type: 'object',
   required: ['name', 'description', 'type'],
   properties: {
-    id: {
+    _id: {
       type: 'string',
       format: 'uuid'
     },

--- a/src/schema/relation.js
+++ b/src/schema/relation.js
@@ -4,7 +4,7 @@ const relationSchema = {
   type: 'object',
   required: ['description', 'source', 'target'],
   properties: {
-    id: {
+    _id: {
       type: 'string'
     },
     description: {

--- a/src/util/fiqlQueryBuilder.js
+++ b/src/util/fiqlQueryBuilder.js
@@ -49,17 +49,22 @@ function buildQuery (model, params) {
     }
   }
 
-  let query = {}
+  const result = { }
   if (aggs.length <= 0) {
-    query = model.find(filters)
+    result.countQuery = model.count(filters)
     if (selectFields.length > 0) {
-      query = query.select(selectFields.join(' '))
+      result.pageQuery = model.find(filters).select(selectFields.join(' '))
+    } else {
+      result.pageQuery = model.find(filters)
     }
   } else {
-    query = model.aggregate(aggs)
+    result.pageQuery = model.aggregate(aggs)
+    result.countQuery = model.aggregate(aggs.concat({ $count: 'count' }))
   }
 
-  return query.skip(parseInt(params.skip)).limit(parseInt(params.limit))
+  result.pageQuery = result.pageQuery.skip(parseInt(params.skip)).limit(parseInt(params.limit))
+
+  return result
 }
 
 const _buildQuery = (model, parsedFiql) => {

--- a/src/util/page.js
+++ b/src/util/page.js
@@ -62,7 +62,7 @@ class Page {
     return `${collectionPath}?offset=${offset}&limit=${limit}`
   }
 
-  static getSelfLink (collectionPath, dataItem, idProperties = ['id']) {
+  static getSelfLink (collectionPath, dataItem, idProperties = ['_id']) {
     return `${collectionPath}`.concat(
       idProperties.map((p) => `/${dataItem[p]}`)
     )

--- a/src/util/page.js
+++ b/src/util/page.js
@@ -120,12 +120,19 @@ class Page {
 
   getData (data) {
     return data.map((d) => {
-      return {
-        ...d._doc,
-        _links: {
-          self: this.options.selfLinkBuilder(this.collectionPath, d)
-        }
-      }
+      return d._doc
+        ? {
+            ...d._doc,
+            _links: {
+              self: this.options.selfLinkBuilder(this.collectionPath, d)
+            }
+          }
+        : {
+            ...d,
+            _links: {
+              self: this.options.selfLinkBuilder(this.collectionPath, d)
+            }
+          }
     })
   }
 

--- a/src/util/tests/fiqlQueryBuilder.unit.test.js
+++ b/src/util/tests/fiqlQueryBuilder.unit.test.js
@@ -126,7 +126,7 @@ describe('Query Builder', () => {
 
   test('Default query', async () => {
     // ACT
-    const result = await buildQuery(parentModel).query.exec()
+    const result = await buildQuery(parentModel).pageQuery.exec()
 
     // ASSERT
     expect(result.length).toBe(7)
@@ -193,7 +193,7 @@ describe('Query Builder', () => {
       const select = 'child2.name'
 
       // ACT
-      const result = await buildQuery(parentModel, { fields: select }).query.exec()
+      const result = await buildQuery(parentModel, { fields: select }).pageQuery.exec()
 
       // ASSERT
       expect(result[0].name).toBeUndefined()
@@ -206,7 +206,7 @@ describe('Query Builder', () => {
       const select = 'child.name,child.parent.name'
 
       // ACT
-      const result = await buildQuery(parentModel, { fields: select }).query.exec()
+      const result = await buildQuery(parentModel, { fields: select }).pageQuery.exec()
 
       // ASSERT
       expect(result[0].name).toBeUndefined()
@@ -221,7 +221,7 @@ describe('Query Builder', () => {
       const fiql = "name=='Parent 1'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -233,7 +233,7 @@ describe('Query Builder', () => {
       const fiql = "name!='Parent 1'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(6)
@@ -245,7 +245,7 @@ describe('Query Builder', () => {
       const fiql = "name=gt='Parent 5'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -257,7 +257,7 @@ describe('Query Builder', () => {
       const fiql = "name=ge='Parent 5'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(3)
@@ -270,7 +270,7 @@ describe('Query Builder', () => {
       const fiql = "name=lt='Parent 2'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -281,7 +281,7 @@ describe('Query Builder', () => {
       const fiql = 'name=le=Parent%202'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -295,8 +295,8 @@ describe('Query Builder', () => {
       const fiql2 = "name=re='.*blue.*'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
-      const result2 = await buildQuery(parentModel, { fiql: fiql2 }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
+      const result2 = await buildQuery(parentModel, { fiql: fiql2 }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -308,7 +308,7 @@ describe('Query Builder', () => {
       const fiql = "child.name=re=('1$',gi)"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -334,7 +334,7 @@ describe('Query Builder', () => {
       const fiql = 'age==20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -346,7 +346,7 @@ describe('Query Builder', () => {
       const fiql = 'age!=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(6)
@@ -357,7 +357,7 @@ describe('Query Builder', () => {
       const fiql = 'age=gt=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(5)
@@ -368,7 +368,7 @@ describe('Query Builder', () => {
       const fiql = 'age=ge=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(6)
@@ -379,7 +379,7 @@ describe('Query Builder', () => {
       const fiql = 'age=lt=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -390,7 +390,7 @@ describe('Query Builder', () => {
       const fiql = 'age=le=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -405,7 +405,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt==1995-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -419,7 +419,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt!=1995-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(6)
@@ -430,7 +430,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt=gt=1999-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -441,7 +441,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt=ge=1999-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -452,7 +452,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt=lt=1995-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -463,7 +463,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt=le=1995-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -477,8 +477,8 @@ describe('Query Builder', () => {
       const fiql2 = 'active==0'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
-      const result2 = await buildQuery(parentModel, { fiql: fiql2 }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
+      const result2 = await buildQuery(parentModel, { fiql: fiql2 }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(3)
@@ -492,7 +492,7 @@ describe('Query Builder', () => {
       const fiql = 'active==true;age==10'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -504,7 +504,7 @@ describe('Query Builder', () => {
       const fiql = 'active==false,age==10'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(5)
@@ -515,7 +515,7 @@ describe('Query Builder', () => {
       const fiql = '(active==true;age==10),(active==false;age!=40)'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(4)
@@ -528,7 +528,7 @@ describe('Query Builder', () => {
       const fiql = 'nestedChild._id==NC01'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -540,7 +540,7 @@ describe('Query Builder', () => {
       const fiql = 'child._id==C06'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -553,7 +553,7 @@ describe('Query Builder', () => {
       const fiql = 'child.subChild._id==C02'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -565,7 +565,7 @@ describe('Query Builder', () => {
       const fiql = 'child.subChild._id==C02,child.subChild._id==C03'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -578,7 +578,7 @@ describe('Query Builder', () => {
       const fiql = 'childsArray._id==C02'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result = await buildQuery(parentModel, { fiql }).pageQuery.exec()
 
       // ASSERT
       expect(result.length).toBe(1)

--- a/src/util/tests/fiqlQueryBuilder.unit.test.js
+++ b/src/util/tests/fiqlQueryBuilder.unit.test.js
@@ -126,7 +126,7 @@ describe('Query Builder', () => {
 
   test('Default query', async () => {
     // ACT
-    const result = await buildQuery(parentModel).exec()
+    const result = await buildQuery(parentModel).query.exec()
 
     // ASSERT
     expect(result.length).toBe(7)
@@ -134,7 +134,7 @@ describe('Query Builder', () => {
 
   test('Limit', async () => {
     // ACT
-    const result = await buildQuery(parentModel, { limit: 5 }).exec()
+    const result = await buildQuery(parentModel, { limit: 5 }).pageQuery.exec()
 
     // ASSERT
     expect(result.length).toBe(5)
@@ -142,7 +142,7 @@ describe('Query Builder', () => {
 
   test('Skip', async () => {
     // ACT
-    const result = await buildQuery(parentModel, { limit: 1, skip: 1 }).exec()
+    const result = await buildQuery(parentModel, { limit: 1, skip: 1 }).pageQuery.exec()
 
     // ASSERT
     expect(result.length).toBe(1)
@@ -155,7 +155,7 @@ describe('Query Builder', () => {
       const select = 'name'
 
       // ACT
-      const result = await buildQuery(parentModel, { fields: select }).exec()
+      const result = await buildQuery(parentModel, { fields: select }).pageQuery.exec()
 
       // ASSERT
       expect(result[0].name).toBe('Parent 1')
@@ -167,7 +167,7 @@ describe('Query Builder', () => {
       const select = 'name,active'
 
       // ACT
-      const result = await buildQuery(parentModel, { fields: select }).exec()
+      const result = await buildQuery(parentModel, { fields: select }).pageQuery.exec()
 
       // ASSERT
       expect(result[0].name).toBe('Parent 1')
@@ -180,7 +180,7 @@ describe('Query Builder', () => {
       const select = 'child.name'
 
       // ACT
-      const result = await buildQuery(parentModel, { fields: select }).exec()
+      const result = await buildQuery(parentModel, { fields: select }).pageQuery.exec()
 
       // ASSERT
       expect(result[0].name).toBeUndefined()
@@ -193,7 +193,7 @@ describe('Query Builder', () => {
       const select = 'child2.name'
 
       // ACT
-      const result = await buildQuery(parentModel, { fields: select }).exec()
+      const result = await buildQuery(parentModel, { fields: select }).query.exec()
 
       // ASSERT
       expect(result[0].name).toBeUndefined()
@@ -206,7 +206,7 @@ describe('Query Builder', () => {
       const select = 'child.name,child.parent.name'
 
       // ACT
-      const result = await buildQuery(parentModel, { fields: select }).exec()
+      const result = await buildQuery(parentModel, { fields: select }).query.exec()
 
       // ASSERT
       expect(result[0].name).toBeUndefined()
@@ -221,7 +221,7 @@ describe('Query Builder', () => {
       const fiql = "name=='Parent 1'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -233,7 +233,7 @@ describe('Query Builder', () => {
       const fiql = "name!='Parent 1'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(6)
@@ -245,7 +245,7 @@ describe('Query Builder', () => {
       const fiql = "name=gt='Parent 5'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -257,7 +257,7 @@ describe('Query Builder', () => {
       const fiql = "name=ge='Parent 5'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(3)
@@ -270,7 +270,7 @@ describe('Query Builder', () => {
       const fiql = "name=lt='Parent 2'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -281,7 +281,7 @@ describe('Query Builder', () => {
       const fiql = 'name=le=Parent%202'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -295,8 +295,8 @@ describe('Query Builder', () => {
       const fiql2 = "name=re='.*blue.*'"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
-      const result2 = await buildQuery(parentModel, { fiql: fiql2 }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result2 = await buildQuery(parentModel, { fiql: fiql2 }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -308,7 +308,7 @@ describe('Query Builder', () => {
       const fiql = "child.name=re=('1$',gi)"
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -334,7 +334,7 @@ describe('Query Builder', () => {
       const fiql = 'age==20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -346,7 +346,7 @@ describe('Query Builder', () => {
       const fiql = 'age!=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(6)
@@ -357,7 +357,7 @@ describe('Query Builder', () => {
       const fiql = 'age=gt=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(5)
@@ -368,7 +368,7 @@ describe('Query Builder', () => {
       const fiql = 'age=ge=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(6)
@@ -379,7 +379,7 @@ describe('Query Builder', () => {
       const fiql = 'age=lt=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -390,7 +390,7 @@ describe('Query Builder', () => {
       const fiql = 'age=le=20'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -405,7 +405,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt==1995-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -419,7 +419,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt!=1995-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(6)
@@ -430,7 +430,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt=gt=1999-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -441,7 +441,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt=ge=1999-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -452,7 +452,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt=lt=1995-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -463,7 +463,7 @@ describe('Query Builder', () => {
       const fiql = 'includedAt=le=1995-12-17T03:24:00.000-03:00'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -477,8 +477,8 @@ describe('Query Builder', () => {
       const fiql2 = 'active==0'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
-      const result2 = await buildQuery(parentModel, { fiql: fiql2 }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
+      const result2 = await buildQuery(parentModel, { fiql: fiql2 }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(3)
@@ -492,7 +492,7 @@ describe('Query Builder', () => {
       const fiql = 'active==true;age==10'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -504,7 +504,7 @@ describe('Query Builder', () => {
       const fiql = 'active==false,age==10'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(5)
@@ -515,7 +515,7 @@ describe('Query Builder', () => {
       const fiql = '(active==true;age==10),(active==false;age!=40)'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(4)
@@ -528,7 +528,7 @@ describe('Query Builder', () => {
       const fiql = 'nestedChild._id==NC01'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -540,7 +540,7 @@ describe('Query Builder', () => {
       const fiql = 'child._id==C06'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -553,7 +553,7 @@ describe('Query Builder', () => {
       const fiql = 'child.subChild._id==C02'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)
@@ -565,7 +565,7 @@ describe('Query Builder', () => {
       const fiql = 'child.subChild._id==C02,child.subChild._id==C03'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(2)
@@ -578,7 +578,7 @@ describe('Query Builder', () => {
       const fiql = 'childsArray._id==C02'
 
       // ACT
-      const result = await buildQuery(parentModel, { fiql }).exec()
+      const result = await buildQuery(parentModel, { fiql }).query.exec()
 
       // ASSERT
       expect(result.length).toBe(1)


### PR DESCRIPTION
To enable FIQL as it is, change all ids to UUID. This is a temporary fix and maybe will be changed on the future, when we decide about ID type on #25 

Signed-off-by: Francisco Ribas <chico.bribas@gmail.com>